### PR TITLE
AE-335: Expose all versions of documentation

### DIFF
--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -7,14 +7,14 @@
   </span>
   <div class="rst-other-versions">
     <dl>
-      <dt id="bf-versions-list">{{ _('Versions') }}</dt>
+      <dt id="blackfynn-versions-list">{{ _('Versions') }}</dt>
     </dl>
    </div>
 </div>
 
 <script type="text/javascript">
   function addVersionLink(version) {
-    var versions = document.querySelector("#bf-versions-list");
+    var versions = document.querySelector("#blackfynn-versions-list");
     var entry = document.createElement('dd');
     var link = document.createElement('a')
     link.textContent = version;
@@ -32,7 +32,7 @@
   request.onload = function() {
     var releases = request.response.releases;
     addVersionLink('latest');
-    Object.keys(releases).sort().reverse().forEach(function(versionNumber) {
+    Object.keys(releases).filter(function(v) {return v > '2.3.1'}).sort().reverse().forEach(function(versionNumber) {
       if (releases.hasOwnProperty(versionNumber)) {
         addVersionLink(versionNumber)
       }

--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -1,4 +1,3 @@
-<div> {{ versions }}</div>
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">
     <span class="fa fa-book"> </span>

--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -7,34 +7,37 @@
   </span>
   <div class="rst-other-versions">
     <dl>
-      <dt id="blackfynn-versions-list">{{ _('Versions') }}</dt>
+      <dt id="blackfynn-version-list">{{ _('Versions') }}</dt>
     </dl>
    </div>
 </div>
 
 <script type="text/javascript">
+
+  // Add a link to the given version of the documentation
   function addVersionLink(version) {
-    var versions = document.querySelector("#blackfynn-versions-list");
+    var versions = document.querySelector("#blackfynn-version-list");
     var entry = document.createElement('dd');
     var link = document.createElement('a')
     link.textContent = version;
-    link.href = 'http://docs.blackfynn.io/python/' + version;
+    link.href = '{{ root_url }}' + version;
     entry.appendChild(link);
     versions.appendChild(entry);
   }
 
+  // Get version info from PyPi
   var url = 'https://pypi.org/pypi/blackfynn/json';
   var request = new XMLHttpRequest();
-  request.open('GET', url);
+  request.open('GET', '{{ pypi_url }}');
   request.responseType = 'json';
   request.send();
 
   request.onload = function() {
-    var releases = request.response.releases;
     addVersionLink('latest');
-    Object.keys(releases).filter(function(v) {return v > '2.3.1'}).sort().reverse().forEach(function(versionNumber) {
-      if (releases.hasOwnProperty(versionNumber)) {
-        addVersionLink(versionNumber)
+    Object.keys(request.response.releases).sort().reverse().forEach(function(version) {
+      // versions older than 2.3.1 don't have documentation
+      if (version > '2.3.1') {
+        addVersionLink(version)
       }
     });
   }

--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -1,37 +1,41 @@
-{% if READTHEDOCS %}
-{# Add rst-badge after rst-versions for small badge style. #}
-  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
-    <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> Read the Docs</span>
-      v: {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
-      <dl>
-        <dt>{{ _('Versions') }}</dt>
-        {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        <dt>{{ _('Downloads') }}</dt>
-        {% for type, url in downloads %}
-          <dd><a href="{{ url }}">{{ type }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        <dt>{{ _('On Read the Docs') }}</dt>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
-          </dd>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
-          </dd>
-      </dl>
-      <hr/>
-      {% trans %}Free document hosting provided by <a href="http://www.readthedocs.org">Read the Docs</a>.{% endtrans %}
+<div> {{ versions }}</div>
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> </span>
+    v: {{ version }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    <dl>
+      <dt id="bf-versions-list">{{ _('Versions') }}</dt>
+    </dl>
+   </div>
+</div>
 
-    </div>
-  </div>
-{% endif %}
+<script type="text/javascript">
+  function addVersionLink(version) {
+    var versions = document.querySelector("#bf-versions-list");
+    var entry = document.createElement('dd');
+    var link = document.createElement('a')
+    link.textContent = version;
+    link.href = 'http://docs.blackfynn.io/python/' + version;
+    entry.appendChild(link);
+    versions.appendChild(entry);
+  }
 
+  var url = 'https://pypi.org/pypi/blackfynn/json';
+  var request = new XMLHttpRequest();
+  request.open('GET', url);
+  request.responseType = 'json';
+  request.send();
+
+  request.onload = function() {
+    var releases = request.response.releases;
+    addVersionLink('latest');
+    Object.keys(releases).sort().reverse().forEach(function(versionNumber) {
+      if (releases.hasOwnProperty(versionNumber)) {
+        addVersionLink(versionNumber)
+      }
+    });
+  }
+</script>


### PR DESCRIPTION
Pull published versions from PyPI. 

Needs some styling from someone with frontend chops. @clohr, maybe you could assist?
![screen shot 2018-10-05 at 2 06 25 pm](https://user-images.githubusercontent.com/2666107/46552163-dd23ba80-c8a7-11e8-80e3-1b7f914d6a4a.png)

This change requires the following values to be added to the `html_context` variable in `blackfynn-python/docs/conf.py`:

```
    pypi_url = 'https://pypi.org/pypi/blackfynn/json',
    root_url = 'http://docs.blackfynn.io/python/'
```

These could also be hardcoded.