### PR TITLE
Pull base URL from PyPi JSON

### DIFF
--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -15,24 +15,39 @@
 <script type="text/javascript">
 
   // Add a link to the given version of the documentation
-  function addVersionLink(fragment, version) {
+  function addVersionLink(fragment, baseUrl, version) {
     var entry = document.createElement('dd');
     var link = document.createElement('a')
     link.textContent = version;
-    link.href = '{{ root_url }}' + version;
+    link.href = baseUrl + version + '/index.html';
     entry.appendChild(link);
     fragment.appendChild(entry);
   }
-  
+
   function displayReleases(fragment, json) {
-    // add link to latest
-    addVersionLink(fragment, 'latest');
-    
+
+    // get docs URL from PyPi project_urls field, if it exists
+    var baseUrl = json &&
+        json.info &&
+        json.info.project_urls &&
+        json.info.project_urls.Documentation;
+
+    // default, if not found
+    if (!baseUrl) {
+      baseUrl = '/python/'
+    }
+    if (baseUrl[baseUrl.length - 1] != '/') {
+      baseUrl += '/';
+    }
+
+    // add link to latest version
+    addVersionLink(fragment, baseUrl, 'latest');
+
     var releases = json && json.releases ? Object.keys(json.releases) : []
     releases.sort().reverse().forEach(function(version) {
       // versions older than 2.3.1 don't have documentation
       if (version > '2.3.1') {
-        addVersionLink(fragment, version);
+        addVersionLink(fragment, baseUrl, version);
       }
     });
   }


### PR DESCRIPTION
PyPi has a `project_urls` field for linking to project web pages (eg source code, bug tracker.) This PR updates the version link creation to use a special `Documentation` URL (added in https://github.com/Blackfynn/blackfynn-python/pull/89) instead of embedding the URL in the docs via a Sphinx template variable.

The big benefit here is that we can change the `Documentation` project URL in a `blackfynn` release and we won't have to rebuild old versions of the documentation to point to a new documentation URL.